### PR TITLE
Fix: 'arguments' shown as object, must be array

### DIFF
--- a/README.org
+++ b/README.org
@@ -132,11 +132,12 @@ let options = [
 ~arguments~ require less configuration. This is an optional argument to ~opts.parse~:
 
 #+BEGIN_SRC javascript
-let arguments =
-  { name     : 'script',
-    required : true, // not required by default
-    callback : function (value) { ... },
-  };
+let arguments = [
+    { name     : 'script',
+      required : true, // not required by default
+      callback : function (value) { ... },
+    };
+  ]
 #+END_SRC
 
 *** help text generator


### PR DESCRIPTION
`arguments` must be boolean or an Array. 
The README it is shown as object: 

```javascript
let arguments =
  { name     : 'script',
    required : true, // not required by default
    callback : function (value) { ... },
  };

// Will throw an error
opts.parse(options, arguments, help)
```